### PR TITLE
fix: delete queries/controls unmodified in the last 2 minutes

### DIFF
--- a/.github/workflows/dev.yml
+++ b/.github/workflows/dev.yml
@@ -52,6 +52,16 @@ jobs:
           inlineScript: |
             az storage blob upload-batch --connection-string $(echo "$AZ_ST_CONN_STRING" | base64 -d) --destination grc/queries --source ./queries --overwrite
             az storage blob upload-batch --connection-string $(echo "$AZ_ST_CONN_STRING" | base64 -d) --destination grc/controls --source ./controls --overwrite
+      - name: Delete old entries (unmodified within the last 2 minutes)
+        env:
+          AZ_ST_CONN_STRING: ${{ secrets.DEV_AZ_ST_CONN_STRING }}
+        uses: azure/CLI@v1
+        with:
+          azcliversion: 2.37.0
+          inlineScript: |
+            modified_since=$(gdate --utc -d "-2 min" "+%Y-%m-%dT%H:%MZ")
+            az storage blob delete-batch -s grc --connection-string $(echo "$AZ_ST_CONN_STRING" | base64 -d) --pattern 'queries/*' --if-unmodified-since $modified_since
+            az storage blob delete-batch -s grc --connection-string $(echo "$AZ_ST_CONN_STRING" | base64 -d) --pattern 'controls/*' --if-unmodified-since $modified_since
       - name: Update
         shell: bash
         env:

--- a/.github/workflows/prod.yml
+++ b/.github/workflows/prod.yml
@@ -15,14 +15,6 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v3
-      - name: Get changed files
-        id: changed-files
-        uses: tj-actions/changed-files@v32
-      - name: List all changed files
-        run: |
-          for file in ${{ steps.changed-files.outputs.all_changed_files }}; do
-            echo "$file was changed"
-          done
       - name: Copy
         env:
           AZ_ST_CONN_STRING: ${{ secrets.PROD_AZ_ST_CONN_STRING }}
@@ -32,6 +24,16 @@ jobs:
           inlineScript: |
             az storage blob upload-batch --connection-string $(echo "$AZ_ST_CONN_STRING" | base64 -d) --destination grc/queries --source ./queries --overwrite
             az storage blob upload-batch --connection-string $(echo "$AZ_ST_CONN_STRING" | base64 -d) --destination grc/controls --source ./controls --overwrite
+      - name: Delete old entries (unmodified within the last 2 minutes)
+        env:
+          AZ_ST_CONN_STRING: ${{ secrets.PROD_AZ_ST_CONN_STRING }}
+        uses: azure/CLI@v1
+        with:
+          azcliversion: 2.37.0
+          inlineScript: |
+            modified_since=$(gdate --utc -d "-2 min" "+%Y-%m-%dT%H:%MZ")
+            az storage blob delete-batch -s grc --connection-string $(echo "$AZ_ST_CONN_STRING" | base64 -d) --pattern 'queries/*' --if-unmodified-since $modified_since
+            az storage blob delete-batch -s grc --connection-string $(echo "$AZ_ST_CONN_STRING" | base64 -d) --pattern 'controls/*' --if-unmodified-since $modified_since
       - name: Update
         shell: bash
         env:


### PR DESCRIPTION
This PR adds a new step to the deployment pipeline in which we delete the queries/controls that have not been modified within the last 2 minutes. Since this step takes place after the upload, it will effectively delete the queries/controls that are no longer part of the repo