### PR TITLE
fix: ECS control and queries slugs, white spaces

### DIFF
--- a/controls/aws-ecs-1-privileged-network-mode.json
+++ b/controls/aws-ecs-1-privileged-network-mode.json
@@ -1,20 +1,16 @@
 {
   "name": "Make sure that Amazon ECS task definitions include secure networking modes and user definitions.",
-  "slug": "aws-ecs-1",
+  "slug": "aws-ecs-1-privileged-network-mode",
   "body": "Amazon Elastic Container Service (ECS) [task definitions](https://docs.aws.amazon.com/AmazonECS/latest/developerguide/task_definitions.html) are JSON files that describe how a Docker container should be launched within an ECS cluster.\n\nThis control only evaluates the in-use (RUNNING Task) revision of an Amazon ECS task definition, configured with the `host` network mode, exhibits unexpected privilege escalation on the host container.\n\nIf the `privileged` parameter is set to `true` or the `user` parameter is set to `root` or any other highly privileged user, it can lead to security concerns. These containers have elevated privileges, enabling them to access resources and perform operations that are typically restricted.",
   "remediationDescription": "To remediate this issue, identify the task definitions with the `host` network mode and elevated privileges, and update their parameters accordingly. You can achieve this by creating a new task definition revision using the following steps:\n\n1. Open the Amazon ECS classic [console](https://console.aws.amazon.com/ecs/).\n2. Choose the region that contains your task definition.\n3. In the navigation pane, select \"task definitions.\"\n4. On the task definitions page, select the checkbox next to the task definition that needs revision, and choose **Create new revision**.\n5. Update the `privileged` parameter to `false` and/or change the `user` parameter to a low-privileged user.\n6. If your task definition is used in a service, update your service with the updated task definition. For more information, refer to the [AWS documentation](https://docs.aws.amazon.com/AmazonECS/latest/developerguide/update-service-console-v2.html).",
   "severity": 3,
   "rules": [
     {
-      "subjects": [
-        "ECSTaskDefinition"
-      ],
-      "query": "ecs-task-definitions-secure-privileges",
+      "subjects": ["ECSTaskDefinition"],
+      "query": "aws-ecs-1-privileged-network-mode-query",
       "expectedResult": "[]",
       "comparator": "eq",
-      "cloudProviders": [
-        "aws"
-      ]
+      "cloudProviders": ["aws"]
     }
   ],
   "alertForSecondaryOnly": false

--- a/controls/aws-ecs-10-latest-platform-version.json
+++ b/controls/aws-ecs-10-latest-platform-version.json
@@ -1,21 +1,17 @@
 {
   "alertForSecondaryOnly": false,
   "name": "ECS Fargate services should run on the latest Fargate platform version",
-  "slug": "aws-ecs-10-latest-platformversion",
+  "slug": "aws-ecs-10-latest-platform-version",
   "severity": 2,
   "remediationDescription": "To update an existing service, including its platform version, see [Updating a service](https://docs.aws.amazon.com/AmazonECS/latest/developerguide/update-service.html) in the Amazon Elastic Container Service Developer Guide.",
   "body": "Amazon ECS Fargate services should run the latest Fargate platform version. \n\nAWS Fargate platform versions refer to a specific runtime environment for Fargate task infrastructure, which is a combination of kernel and container runtime versions. New platform versions are released as the runtime environment evolves. For example, a new version may be released for kernel or operating system updates, new features, bug fixes, or security updates. Security updates and patches are deployed automatically for your Fargate tasks. If a security issue is found that affects a platform version, AWS patches the platform version.",
   "rules": [
     {
-      "cloudProviders": [
-        "aws"
-      ],
+      "cloudProviders": ["aws"],
       "comparator": "eq",
       "expectedResult": "[]",
-      "subjects": [
-        "ECSService"
-      ],
-      "query": "aws-ecs-10-fargate-service-no-latest-platform-version"
+      "subjects": ["ECSService"],
+      "query": "aws-ecs-10-latest-platform-version-query"
     }
   ]
 }

--- a/controls/aws-ecs-12-clusters-should-use-insights.json
+++ b/controls/aws-ecs-12-clusters-should-use-insights.json
@@ -1,21 +1,17 @@
 {
   "alertForSecondaryOnly": false,
   "name": "Ensure ECS clusters use Container Insights",
-  "slug": "aws-ecs-12-clusters-should-use-container-insights",
+  "slug": "aws-ecs-12-clusters-should-use-insights",
   "body": "Container Insights collects metrics at the cluster, task, and service levels.\nThis control checks if ECS clusters use Container Insights. This control fails if Container Insights are not set up for a cluster.\nMonitoring is an important part of maintaining the reliability, availability, and performance of Amazon ECS clusters. Use CloudWatch Container Insights to collect, aggregate, and summarize metrics and logs from your containerized applications and microservices. CloudWatch automatically collects metrics for many resources, such as CPU, memory, disk, and network. Container Insights also provides diagnostic information, such as container restart failures, to help you isolate issues and resolve them quickly. You can also set CloudWatch alarms on metrics that Container Insights collects.",
   "severity": 2,
   "remediationDescription": "To use Container Insights, see [Updating a service](https://docs.aws.amazon.com/AmazonCloudWatch/latest/monitoring/deploy-container-insights-ECS.html) in the Amazon CloudWatch User Guide.\n\nTo deploy the CloudWatch agent to collect instance-level metrics from Amazon ECS clusters that are hosted on EC2 instance, use a quick start setup with a default configuration, or install the agent manually to be able to customize it.\n\n1﻿. [Quick setup using AWS CloudFormation](https://docs.aws.amazon.com/AmazonCloudWatch/latest/monitoring/deploy-container-insights-ECS-instancelevel.html#deploy-container-insights-ECS-instancelevel-quickstart)\n\n2﻿. [Manual and custom setup](https://docs.aws.amazon.com/AmazonCloudWatch/latest/monitoring/deploy-container-insights-ECS-instancelevel.html#deploy-container-insights-ECS-instancelevel-manual)",
   "rules": [
     {
-      "cloudProviders": [
-        "aws"
-      ],
+      "cloudProviders": ["aws"],
       "comparator": "eq",
       "expectedResult": "[]",
-      "subjects": [
-        "ECSCluster"
-      ],
-      "query": "aws-ecs-12"
+      "subjects": ["ECSCluster"],
+      "query": "aws-ecs-12-clusters-should-use-insights-query"
     }
   ]
 }

--- a/controls/aws-ecs-2-service-assign-public-ip-disabled.json
+++ b/controls/aws-ecs-2-service-assign-public-ip-disabled.json
@@ -1,19 +1,15 @@
 {
   "alertForSecondaryOnly": false,
   "name": "Ensure ECS services don't have public IP addresses assigned to them automatically",
-  "slug": "ecs-2-service-assign-public-ip-disabled",
+  "slug": "aws-ecs-2-service-assign-public-ip-disabled",
   "body": "This control checks whether Amazon ECS services are configured to automatically assign public IP addresses.\nA public IP address is an IP address that is reachable from the internet. If you launch your Amazon ECS instances with a public IP address, then your Amazon ECS instances are reachable from the internet. Amazon ECS services should not be publicly accessible, as this may allow unintended access to your container application servers.\n",
   "remediationDescription": "To disable automatic public IP assignment, see [To configure VPC and security group settings for your service](https://docs.aws.amazon.com/AmazonECS/latest/developerguide/service-configure-network.html) in the Amazon Elastic Container Service Developer Guide.\n\nThis control fails if AssignPublicIP is ENABLED. This control passes if AssignPublicIP is DISABLED.\n\nFor tasks that are hosted on Amazon EC2 instances, the awsvpc network mode doesn't provide task ENIs with public IP addresses. To access the internet, tasks that are hosted on Amazon EC2 instances can be launched in a private subnet that's configured to use a [NAT gateway](https://docs.aws.amazon.com/vpc/latest/userguide/vpc-nat-gateway.html).\n\nTo configure VPC and security group settings for your service\n1. If you host tasks on EC2 instances, for Cluster VPC, choose the VPC that your instances are in.\n\n2. For Subnets, choose the available subnets for your service task placement.\n\n3. For Security groups, choose a security group was created for your service's tasks. This security group allows HTTP traffic access from the internet (0.0.0.0/0). To edit the name or the rules of this security group or to choose an existing security group, choose Edit and then modify your security group settings.\n\n4. For Auto-assign Public IP, choose whether to have your tasks receive a public IP address. For tasks on Fargate, for the task to pull the container image, it must either use a public subnet and be assigned a public IP address or a private subnet that has a route to the internet or a NAT gateway that can route requests to the internet.\n",
   "severity": 3,
   "rules": [
     {
-      "query": "aws-ecs-2-service-assign-public-ip-disabled",
-      "subjects": [
-        "ECSService"
-      ],
-      "cloudProviders": [
-        "aws"
-      ],
+      "query": "aws-ecs-2-service-assign-public-ip-disabled-query",
+      "subjects": ["ECSService"],
+      "cloudProviders": ["aws"],
       "comparator": "eq",
       "expectedResult": "[]"
     }

--- a/controls/aws-ecs-3-process-name-space.json
+++ b/controls/aws-ecs-3-process-name-space.json
@@ -4,18 +4,14 @@
   "severity": 3,
   "remediationDescription": "PID mode should not be set to `host`.\n\nPID mode is the process namespace to use for the containers in the task. The valid values are `host` or `task`. If `host` is specified, all containers within the tasks that specified the host PID mode on the same container instance share the same process namespace with the host Amazon EC2 instance. If `task` is specified, all containers within the specified task share the same process namespace. If no value is specified, the default is a private namespace.\n\nIf the `host` PID mode is used, there's a heightened risk of undesired process namespace exposure.\n\nTo configure the pidMode on a task definition, see [Task definition parameters](https://docs.aws.amazon.com/AmazonECS/latest/developerguide/task_definition_parameters.html#task_definition_pidmode) in the Amazon Elastic Container Service Developer Guide.\n",
   "body": "A process ID (PID) namespace provides separation between processes. It prevents system processes from being visible, and allows PIDs to be reused, including PID 1. If the host's PID namespace is shared with containers, it would allow containers to see all of the processes on the host system. This reduces the benefit of process level isolation between the host and the containers. These circumstances could lead to unauthorized access to processes on the host itself, including the ability to manipulate and terminate them. Customers shouldn't share the host's process namespace with containers running on it. This control only evaluates the in-use (RUNNING Task) revision of an Amazon ECS task definition.",
-  "slug": "aws-ecs-3-process-namespace",
+  "slug": "aws-ecs-3-process-names-pace",
   "rules": [
     {
-      "cloudProviders": [
-        "aws"
-      ],
+      "cloudProviders": ["aws"],
       "comparator": "eq",
       "expectedResult": "[]",
-      "query": "aws-ecs-3-task-definition-pidmode-host",
-      "subjects": [
-        "ECSTaskDefinition"
-      ]
+      "query": "aws-ecs-3-process-name-space-query",
+      "subjects": ["ECSTaskDefinition"]
     }
   ]
 }

--- a/controls/aws-ecs-3-process-name-space.json
+++ b/controls/aws-ecs-3-process-name-space.json
@@ -4,7 +4,7 @@
   "severity": 3,
   "remediationDescription": "PID mode should not be set to `host`.\n\nPID mode is the process namespace to use for the containers in the task. The valid values are `host` or `task`. If `host` is specified, all containers within the tasks that specified the host PID mode on the same container instance share the same process namespace with the host Amazon EC2 instance. If `task` is specified, all containers within the specified task share the same process namespace. If no value is specified, the default is a private namespace.\n\nIf the `host` PID mode is used, there's a heightened risk of undesired process namespace exposure.\n\nTo configure the pidMode on a task definition, see [Task definition parameters](https://docs.aws.amazon.com/AmazonECS/latest/developerguide/task_definition_parameters.html#task_definition_pidmode) in the Amazon Elastic Container Service Developer Guide.\n",
   "body": "A process ID (PID) namespace provides separation between processes. It prevents system processes from being visible, and allows PIDs to be reused, including PID 1. If the host's PID namespace is shared with containers, it would allow containers to see all of the processes on the host system. This reduces the benefit of process level isolation between the host and the containers. These circumstances could lead to unauthorized access to processes on the host itself, including the ability to manipulate and terminate them. Customers shouldn't share the host's process namespace with containers running on it. This control only evaluates the in-use (RUNNING Task) revision of an Amazon ECS task definition.",
-  "slug": "aws-ecs-3-process-names-pace",
+  "slug": "aws-ecs-3-process-name-space",
   "rules": [
     {
       "cloudProviders": ["aws"],

--- a/controls/aws-ecs-4-containers-non-privileged.json
+++ b/controls/aws-ecs-4-containers-non-privileged.json
@@ -2,19 +2,15 @@
   "alertForSecondaryOnly": false,
   "rules": [
     {
-      "cloudProviders": [
-        "aws"
-      ],
+      "cloudProviders": ["aws"],
       "comparator": "eq",
       "expectedResult": "[]",
-      "subjects": [
-        "ECSTaskDefinition"
-      ],
-      "query": "aws-ecs-4"
+      "subjects": ["ECSTaskDefinition"],
+      "query": "aws-ecs-4-containers-non-privileged"
     }
   ],
   "name": "Ensure ECS containers run as non-privileged",
-  "slug": "aws-ecs-4-containers-run-as-non-privileged",
+  "slug": "aws-ecs-4-containers-non-privileged-query",
   "body": "ECS containers should run as non-privileged. . The control fails if the `privileged` parameter in the container definition of Amazon ECS Task Definitions is set to true. \nWhen the `privilege` parameter is true, the container is given elevated privileges on the host container instance (similar to the root user).\nThis control only evaluates the in-use (RUNNING Task) revision of an Amazon ECS task definition.\n",
   "severity": 3,
   "remediationDescription": "To configure the `privileged` parameter on a task definition, see [Advanced container definition parameters](https://docs.aws.amazon.com/AmazonECS/latest/developerguide/task_definition_parameters.html#container_definition_security) in the Amazon Elastic Container Service Developer Guide.\n\n1﻿.  Open the console at https://console.aws.amazon.com/ecs/v2.\n\n2﻿.  In the navigation pane, choose Task definitions.\n\n3﻿.  Choose Create new revision, Create new revision with JSON.\n\n4﻿.  In the JSON editor box, edit your JSON file and set `privileged` parameter to false.\n\n5﻿.  Choose Create."

--- a/controls/aws-ecs-5-readonly-root-file-systems.json
+++ b/controls/aws-ecs-5-readonly-root-file-systems.json
@@ -1,21 +1,17 @@
 {
   "alertForSecondaryOnly": false,
   "name": "ECS containers should be limited to read-only access to root filesystems",
-  "slug": "aws-ecs-5-readonly-root-filesystems",
+  "slug": "aws-ecs-5-readonly-root-file-systems",
   "severity": 3,
   "remediationDescription": "Limiting container definitions to read-only access to root filesystems (classic Amazon ECS console)\n1. Open the Amazon ECS classic console at https://console.aws.amazon.com/ecs/. Use the classic Amazon ECS console.\n\n2. In the left navigation pane, choose Task Definitions.\n\n3. For each task definition that has container definitions that need to be updated, do the following:\n* Select the container definition that needs to be updated.\n* Choose Edit Container. For Storage and Logging, select Read only root file system.\n* Choose Update at the bottom of the Edit Container tab.\n* Choose Create.",
   "body": "Amazon ECS containers should be limited to read-only access to mounted root filesystems.\n This control only evaluates the in-use (RUNNING Task) revision of an Amazon ECS task definition.",
   "rules": [
     {
-      "cloudProviders": [
-        "aws"
-      ],
+      "cloudProviders": ["aws"],
       "comparator": "eq",
       "expectedResult": "[]",
-      "subjects": [
-        "ECSTaskDefinition"
-      ],
-      "query": "aws-ecs-5-task-definition-readonly-root"
+      "subjects": ["ECSTaskDefinition"],
+      "query": "aws-ecs-5-readonly-root-file-systems-query"
     }
   ]
 }

--- a/controls/aws-ecs-8-secrets-in-vars.json
+++ b/controls/aws-ecs-8-secrets-in-vars.json
@@ -1,21 +1,17 @@
 {
   "alertForSecondaryOnly": false,
   "name": "Make sure secrets are not passed as container environment variables",
-  "slug": "aws-ecs-8",
+  "slug": "aws-ecs-8-secrets-in-vars",
   "body": "Amazon Elastic Container Service (ECS) [task definitions](https://docs.aws.amazon.com/AmazonECS/latest/developerguide/task_definitions.html) are JSON files that describe how a Docker container should be launched within an ECS cluster.\n\nThis control verifies whether the environment parameter of container in an Amazon ECS task definition includes certain key-value pairs (`AWS_ACCESS_KEY_ID`, `AWS_SECRET_ACCESS_KEY`, or `ECS_ENGINE_AUTH_DATA`). It's important to note that this control does not consider environmental variables passed from other sources like Amazon S3. Additionally, this control only evaluates the in-use (RUNNING Task) revision of an Amazon ECS task definition.",
   "severity": 3,
   "remediationDescription": "In AWS, you can safely pass secrets to a task definition in by using AWS Secrets Manager or AWS Systems Manager Parameter Store. These services provide secure storage and management of sensitive information, including API keys, passwords, and database credentials. Here's how you can pass secrets to a task definition:\n\n1. **Store the Secrets**: Use AWS Secrets Manager or AWS Systems Manager Parameter Store to securely store your secrets. These services encrypt the secrets at rest and provide access controls to restrict who can retrieve the secrets.\n2. **Grant Access**: Configure the necessary permissions to allow your ECS task or service to access the stored secrets. This typically involves creating an IAM role with appropriate permissions to access the secret values from Secrets Manager or Parameter Store.\n3. **Update Task Definition**: Modify your task definition to include references to the secrets stored in Secrets Manager or Parameter Store. Instead of hard-coding the secret values directly in the task definition, you use placeholders or environment variables to reference the secrets' ARNs or names.\n4. **Configure Task Execution Role**: Ensure that your ECS task execution role (the role assumed by the ECS agent on the EC2 instances) has the necessary permissions to retrieve the secret values from Secrets Manager or Parameter Store.\n5. **Deploy and Run Tasks**: Launch your tasks or services using the updated task definition. During runtime, the ECS agent will automatically retrieve the secret values from Secrets Manager or Parameter Store and inject them as environment variables or files into the running container.\n\nThe following is a snippet of a task definition showing the format when referencing the full text of a Secrets Manager secret.\n\n```bash\n{\n  \"containerDefinitions\": [{\n    \"secrets\": [{\n      \"name\": \"environment_variable_name\",\n      \"valueFrom\": \"arn:aws:secretsmanager:region:aws_account_id:secret:secret_name-AbCdEf\"\n    }]\n  }]\n}\n```\n\nFor more details refer to [AWS documentation](https://docs.aws.amazon.com/AmazonECS/latest/developerguide/specifying-sensitive-data.html#secrets-create-taskdefinition)",
   "rules": [
     {
-      "cloudProviders": [
-        "aws"
-      ],
+      "cloudProviders": ["aws"],
       "comparator": "eq",
       "expectedResult": "[]",
-      "subjects": [
-        "ECSTaskDefinition"
-      ],
-      "query": "ecs-task-definition-no-env-secrets"
+      "subjects": ["ECSTaskDefinition"],
+      "query": "aws-ecs-8-secrets-in-vars-query"
     }
   ]
 }

--- a/policies/nist-800-53.json
+++ b/policies/nist-800-53.json
@@ -165,16 +165,16 @@
           "control": "okta-weak-password-policies"
         },
         {
-          "control": "aws-ecs-1"
+          "control": "aws-ecs-1-privileged-network-mode"
         },
         {
-          "control": "ecs-2-service-assign-public-ip-disabled"
+          "control": "aws-ecs-2-service-assign-public-ip-disabled"
         },
         {
-          "control": "aws-ecs-4-containers-run-as-non-privileged"
+          "control": "aws-ecs-4-containers-non-privileged"
         },
         {
-          "control": "aws-ecs-5-readonly-root-filesystems"
+          "control": "aws-ecs-5-readonly-root-file-systems"
         }
       ]
     },
@@ -286,7 +286,7 @@
           "control": "azure-1-3-0-networking-5"
         },
         {
-          "control": "aws-ecs-12-clusters-should-use-container-insights"
+          "control": "aws-ecs-12-clusters-should-use-insights"
         }
       ]
     },
@@ -374,10 +374,10 @@
           "control": "azure-1-3-0-networking-4"
         },
         {
-          "control": "aws-ecs-3"
+          "control": "aws-ecs-3-process-name-space"
         },
         {
-          "control": "aws-ecs-8"
+          "control": "aws-ecs-8-secrets-in-vars"
         }
       ]
     },
@@ -415,13 +415,13 @@
           "control": "azure-1-3-0-sc-14"
         },
         {
-          "control": "aws-ecs-3"
+          "control": "aws-ecs-3-process-name-space"
         },
         {
-          "control": "aws-ecs-8"
+          "control": "aws-ecs-8-secrets-in-vars"
         },
         {
-          "control": "aws-ecs-12-clusters-should-use-container-insights"
+          "control": "aws-ecs-12-clusters-should-use-insights"
         }
       ]
     },
@@ -526,13 +526,13 @@
     {
       "name": "Planning",
       "slug": "nist-800-53-planning",
-      "body": " ﻿ ",
+      "body": "",
       "controls": null
     },
     {
       "name": "Risk Assessment",
       "slug": "nist-800-53-risk",
-      "body": " ﻿ ",
+      "body": "",
       "controls": [
         {
           "control": "aws-logging-5"
@@ -552,7 +552,7 @@
     {
       "name": "System and Information Integrity",
       "slug": "nist-800-53-integrity",
-      "body": " ﻿ ",
+      "body": "",
       "controls": [
         {
           "control": "networking-ssh-from-internet"
@@ -681,10 +681,10 @@
           "control": "azure-1-3-0-storage-1"
         },
         {
-          "control": "aws-ecs-12-clusters-should-use-container-insights"
+          "control": "aws-ecs-12-clusters-should-use-insights"
         },
         {
-          "control": "aws-ecs-10-latest-platformversion"
+          "control": "aws-ecs-10-latest-platform-version"
         }
       ]
     },
@@ -832,7 +832,7 @@
           "control": "azure-1-3-0-storage-1"
         },
         {
-          "control": "ecs-2-service-assign-public-ip-disabled"
+          "control": "aws-ecs-2-service-assign-public-ip-disabled"
         }
       ]
     },

--- a/queries/aws-ecs-1-privileged-network-mode-query.json
+++ b/queries/aws-ecs-1-privileged-network-mode-query.json
@@ -1,5 +1,5 @@
 {
   "name": "Check if Amazon ECS task definitions should have secure networking modes and user definitions",
-  "slug": "ecs-task-definitions-secure-privileges",
+  "slug": "aws-ecs-1-privileged-network-mode-query",
   "query": "{\n  ecsTaskDefinitions(\n    where: { \n      networkMode: \"host\", task_NOT: null, \n      OR:[\n        {containerSpecs_SOME: { privileged: true }},\n        {containerSpecs_SOME: { user_CONTAINS: \"root\" }}\n     ] }\n  ) {...AssetFragment}\n}\n"
 }

--- a/queries/aws-ecs-10-latest-platform-version-query.json
+++ b/queries/aws-ecs-10-latest-platform-version-query.json
@@ -1,5 +1,5 @@
 {
-  "slug": "aws-ecs-10-fargate-service-no-latest-platform-version",
+  "slug": "aws-ecs-10-latest-platform-version-query",
   "name": "ECS Services should use the latest platform version",
   "query": "{\n  ecsServices(where: {NOT: { platformVersion_IN: [\"LATEST\", \"\"] }}) {...AssetFragment}\n}"
 }

--- a/queries/aws-ecs-12-clusters-should-use-insights-query.json
+++ b/queries/aws-ecs-12-clusters-should-use-insights-query.json
@@ -1,5 +1,5 @@
 {
   "name": "ECS clusters should use Container Insights",
-  "slug": "aws-ecs-12",
+  "slug": "aws-ecs-12-clusters-should-use-insights-query",
   "query": "{\n  ecsClusters(where: {hasECSSettings_NONE: {\n      key: \"containerInsights\",\n      value: \"enabled\"  \n    }}) {...AssetFragment}\n}"
 }

--- a/queries/aws-ecs-2-service-assign-public-ip-disabled-query.json
+++ b/queries/aws-ecs-2-service-assign-public-ip-disabled-query.json
@@ -1,5 +1,5 @@
 {
-  "slug": "aws-ecs-2-service-assign-public-ip-disabled",
+  "slug": "aws-ecs-2-service-assign-public-ip-disabled-query",
   "name": "ECS services should not have public IP addresses assigned to them automatically",
   "query": "{\n  ecsServices(where: {hasECSServiceNetworkConfigurations_SOME: { assignPublicIP: true}}) {...AssetFragment}\n}"
 }

--- a/queries/aws-ecs-3-process-name-space-query.json
+++ b/queries/aws-ecs-3-process-name-space-query.json
@@ -1,5 +1,5 @@
 {
   "name": "ECS task definitions should not share the host's process namespace",
-  "slug": "aws-ecs-3-task-definition-pidmode-host",
+  "slug": "aws-ecs-3-process-name-space-query",
   "query": "{\n  ecsTaskDefinitions(where:  {pidMode_MATCHES: \"host\", task_NOT: null}) {...AssetFragment}\n}"
 }

--- a/queries/aws-ecs-4-containers-non-privileged-query.json
+++ b/queries/aws-ecs-4-containers-non-privileged-query.json
@@ -1,5 +1,5 @@
 {
   "name": "ECS containers should run as non-privileged",
-  "slug": "aws-ecs-4",
+  "slug": "aws-ecs-4-containers-non-privileged-query",
   "query": "{\n  ecsTaskDefinitions(where: {AND: [\n      {\n        task_NOT: null\n      },\n      {\n        containerSpecs_SOME: {\n          privileged: true\n        }\n      }\n    ]}) {...AssetFragment}\n}"
 }

--- a/queries/aws-ecs-5-readonly-root-file-systems-query.json
+++ b/queries/aws-ecs-5-readonly-root-file-systems-query.json
@@ -1,5 +1,5 @@
 {
-  "slug": "aws-ecs-5-task-definition-readonly-root",
+  "slug": "aws-ecs-5-readonly-root-file-systems-query",
   "query": "{\n  ecsTaskDefinitions(where: {task_NOT: null, containerSpecs_SOME: { readOnlyRootFS: false }}) {...AssetFragment}\n}",
   "name": "ECS containers should be limited to read-only access to root filesystems"
 }

--- a/queries/aws-ecs-8-secrets-in-vars-query.json
+++ b/queries/aws-ecs-8-secrets-in-vars-query.json
@@ -1,5 +1,5 @@
 {
-  "slug": "ecs-task-definition-no-env-secrets",
+  "slug": "aws-ecs-8-secrets-in-vars-query",
   "query": "{\n  ecsTaskDefinitions(\n    where: {\n      task_NOT: null,\n      containerSpecs_SOME: {\n        envEntries_SOME: {\n          key_IN: [\n            \"AWS_ACCESS_KEY_ID\"\n            \"AWS_SECRET_ACCESS_KEY\"\n            \"ECS_ENGINE_AUTH_DATA\"\n          ]\n        }\n      }\n    }\n  ) {...AssetFragment}\n}\n",
   "name": "Check if secrets are passed as ENV vars on ECS Task Definitions"
 }


### PR DESCRIPTION
- I renamed all ECS control and query to a standard format.
- This should fix the cloning issue due to the slug changes while writing the controls and queries.
- I also fixed some indentation and white space issues.
- I deleted the files for old ECS controls and queries from the storage